### PR TITLE
Add Paint by Numbers tool and loading skeleton

### DIFF
--- a/app/tools/loading.tsx
+++ b/app/tools/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 p-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-12">
+          <div className="h-12 w-48 bg-gray-200 rounded-lg mx-auto mb-3 animate-pulse" />
+          <div className="h-6 w-80 bg-gray-200 rounded mx-auto animate-pulse" />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="block bg-white rounded-2xl shadow-md p-6 animate-pulse"
+            >
+              <div className="h-6 w-24 bg-gray-200 rounded-full mb-4" />
+              <div className="h-7 w-40 bg-gray-200 rounded mb-2" />
+              <div className="h-4 w-full bg-gray-200 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -25,6 +25,12 @@ const tools = [
     href: "/tools/swedish",
     color: "from-blue-500 to-purple-500",
   },
+  {
+    name: "Paint by Numbers",
+    description: "Upload an image and convert it to a paint by numbers artwork.",
+    href: "/tools/paintByNumbers",
+    color: "from-orange-500 to-pink-500",
+  },
 ];
 
 export default function ToolsIndex() {


### PR DESCRIPTION
## Summary
Added a new "Paint by Numbers" tool to the tools page and implemented a loading skeleton component for better UX during page transitions.

## Key Changes
- **New Loading Component** (`app/tools/loading.tsx`): Created a skeleton loading screen with animated placeholders that matches the tools grid layout, providing visual feedback while the page loads
- **New Tool Entry**: Added "Paint by Numbers" tool to the tools index that allows users to upload images and convert them to paint-by-numbers artwork
- **Tool Styling**: Applied gradient color scheme (`from-orange-500 to-pink-500`) consistent with existing tool styling patterns

## Implementation Details
- The loading skeleton uses Tailwind's `animate-pulse` utility for smooth animations
- Layout mirrors the actual tools grid (responsive 1 column on mobile, 2 columns on desktop)
- Includes placeholder elements for title, description, and tool cards to provide accurate visual representation during loading

https://claude.ai/code/session_01C2n4ncWxQz7YSuFkgQ5Wbn