### PR TITLE
Add three new audio processing tools: Trimmer, Splitter, and Pitch Shifter

### DIFF
--- a/app/tools/audioPitchShifter/page.tsx
+++ b/app/tools/audioPitchShifter/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL, fetchFile } from "@ffmpeg/util";
+
+export default function AudioPitchShifter() {
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [audioPreviewUrl, setAudioPreviewUrl] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [outputUrl, setOutputUrl] = useState<string | null>(null);
+  const [ffmpegLoaded, setFfmpegLoaded] = useState(false);
+  const [loadingFFmpeg, setLoadingFFmpeg] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [semitones, setSemitones] = useState(0);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const ffmpegRef = useRef<FFmpeg | null>(null);
+
+  const loadFFmpeg = async () => {
+    if (ffmpegLoaded) return;
+    setLoadingFFmpeg(true);
+    setError(null);
+    try {
+      const ffmpeg = new FFmpeg();
+      ffmpegRef.current = ffmpeg;
+      ffmpeg.on("progress", ({ progress: prog }) => {
+        setProgress(Math.round(prog * 100));
+      });
+      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+      await ffmpeg.load({
+        coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+        wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      });
+      setFfmpegLoaded(true);
+    } catch {
+      setError("Failed to load audio processor. Please try again.");
+    } finally {
+      setLoadingFFmpeg(false);
+    }
+  };
+
+  const setFile = (file: File) => {
+    setAudioFile(file);
+    setAudioPreviewUrl(URL.createObjectURL(file));
+    setOutputUrl(null);
+    setError(null);
+    setProgress(0);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith("audio/")) setFile(file);
+  };
+
+  const shiftPitch = async () => {
+    if (!audioFile || !ffmpegRef.current || semitones === 0) return;
+    setProcessing(true);
+    setError(null);
+    setProgress(0);
+    try {
+      const ffmpeg = ffmpegRef.current;
+      const ext = audioFile.name.split(".").pop()?.toLowerCase() || "mp3";
+      await ffmpeg.writeFile(`input.${ext}`, await fetchFile(audioFile));
+
+      // asetrate shifts pitch + speed; atempo compensates speed back to original
+      const rateMultiplier = Math.pow(2, semitones / 12);
+      const tempoMultiplier = 1 / rateMultiplier;
+      // atempo is limited to 0.5–2.0; clamp to valid range
+      const clampedTempo = Math.max(0.5, Math.min(2.0, tempoMultiplier));
+      const filter = `asetrate=44100*${rateMultiplier.toFixed(6)},aresample=44100,atempo=${clampedTempo.toFixed(6)}`;
+
+      await ffmpeg.exec(["-i", `input.${ext}`, "-af", filter, `output.${ext}`]);
+      const data = await ffmpeg.readFile(`output.${ext}`);
+      const blob = new Blob([data], { type: audioFile.type });
+      setOutputUrl(URL.createObjectURL(blob));
+      setProgress(100);
+    } catch {
+      setError("Failed to shift pitch. Please try a different file.");
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const download = () => {
+    if (!outputUrl || !audioFile) return;
+    const link = document.createElement("a");
+    link.href = outputUrl;
+    const base = audioFile.name.replace(/\.[^/.]+$/, "");
+    const ext = audioFile.name.split(".").pop() || "mp3";
+    const sign = semitones > 0 ? "+" : "";
+    link.download = `${base}_pitch${sign}${semitones}.${ext}`;
+    link.click();
+  };
+
+  const reset = () => {
+    setAudioFile(null);
+    setAudioPreviewUrl(null);
+    setOutputUrl(null);
+    setProgress(0);
+    setError(null);
+    setSemitones(0);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const semitoneLabel = semitones === 0
+    ? "No change"
+    : semitones > 0
+    ? `+${semitones} semitone${Math.abs(semitones) !== 1 ? "s" : ""} (higher)`
+    : `${semitones} semitone${Math.abs(semitones) !== 1 ? "s" : ""} (lower)`;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-900 via-purple-800 to-violet-900 py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2">Audio Pitch Shifter</h1>
+          <p className="text-gray-300">Raise or lower the pitch of any audio file by semitones</p>
+        </div>
+
+        {!ffmpegLoaded && (
+          <div className="bg-gray-800 rounded-lg p-8 text-center shadow-xl mb-6">
+            <h2 className="text-xl font-semibold text-white mb-4">Initialize Audio Processor</h2>
+            <p className="text-gray-300 mb-6">
+              Click below to load the audio engine. No files are uploaded — everything runs locally.
+            </p>
+            <button
+              onClick={loadFFmpeg}
+              disabled={loadingFFmpeg}
+              className="bg-violet-600 hover:bg-violet-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-8 rounded-lg transition-colors"
+            >
+              {loadingFFmpeg ? "Loading..." : "Load Audio Processor"}
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-6">
+            <p className="text-red-200">{error}</p>
+          </div>
+        )}
+
+        {ffmpegLoaded && !audioFile && (
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => fileInputRef.current?.click()}
+            className="border-4 border-dashed border-gray-600 rounded-lg p-12 text-center cursor-pointer hover:border-violet-500 transition-colors bg-gray-800/50"
+          >
+            <p className="text-xl text-gray-300 mb-2">Click to upload or drag and drop</p>
+            <p className="text-sm text-gray-500">MP3, WAV, OGG, AAC, FLAC, and more</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="audio/*"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </div>
+        )}
+
+        {ffmpegLoaded && audioFile && (
+          <div className="space-y-6">
+            <div className="bg-gray-800 rounded-lg p-6 shadow-xl">
+              <h2 className="text-xl font-semibold text-white mb-4">Original Audio</h2>
+              <audio
+                src={audioPreviewUrl ?? undefined}
+                controls
+                className="w-full mb-6"
+              />
+
+              <h2 className="text-xl font-semibold text-white mb-4">Pitch Shift</h2>
+              <div className="mb-6">
+                <div className="flex justify-between items-center mb-3">
+                  <span className="text-gray-400 text-sm">−12 (octave down)</span>
+                  <span className="text-white font-semibold text-xl">{semitoneLabel}</span>
+                  <span className="text-gray-400 text-sm">+12 (octave up)</span>
+                </div>
+                <input
+                  type="range"
+                  min="-12"
+                  max="12"
+                  step="1"
+                  value={semitones}
+                  onChange={(e) => {
+                    setSemitones(Number(e.target.value));
+                    setOutputUrl(null);
+                  }}
+                  className="w-full accent-violet-500"
+                />
+                <div className="flex justify-between text-xs text-gray-500 mt-2 px-0.5">
+                  {[-12, -6, 0, 6, 12].map((v) => (
+                    <span key={v}>{v > 0 ? `+${v}` : v}</span>
+                  ))}
+                </div>
+              </div>
+
+              {processing && (
+                <div className="mb-6">
+                  <div className="flex justify-between text-sm text-gray-300 mb-2">
+                    <span>Processing...</span>
+                    <span>{progress}%</span>
+                  </div>
+                  <div className="w-full bg-gray-700 rounded-full h-3">
+                    <div
+                      className="bg-violet-600 h-3 rounded-full transition-all duration-300"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="flex gap-4">
+                {!outputUrl ? (
+                  <button
+                    onClick={shiftPitch}
+                    disabled={processing || semitones === 0}
+                    className="flex-1 bg-violet-600 hover:bg-violet-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                  >
+                    {processing ? "Processing..." : semitones === 0 ? "Move slider to shift pitch" : "Shift Pitch"}
+                  </button>
+                ) : (
+                  <button
+                    onClick={download}
+                    className="flex-1 bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                  >
+                    Download Shifted Audio
+                  </button>
+                )}
+                <button
+                  onClick={reset}
+                  className="bg-red-600 hover:bg-red-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+
+            {outputUrl && (
+              <div className="bg-gray-800 rounded-lg p-6 shadow-xl">
+                <h3 className="text-lg font-semibold text-white mb-4">
+                  Shifted Audio ({semitoneLabel})
+                </h3>
+                <audio src={outputUrl} controls className="w-full" />
+              </div>
+            )}
+
+            <div className="bg-violet-900/30 border border-violet-700 rounded-lg p-4">
+              <h3 className="text-sm font-semibold text-violet-300 mb-2">About this tool:</h3>
+              <ul className="text-sm text-violet-200 space-y-1">
+                <li>• All processing happens in your browser — no files are uploaded</li>
+                <li>• 12 semitones = 1 octave (double or half the frequency)</li>
+                <li>• Tempo is compensated to stay close to the original speed</li>
+                <li>• Large shifts (&gt;6 semitones) may introduce slight artifacts</li>
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/tools/audioSplitter/page.tsx
+++ b/app/tools/audioSplitter/page.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL, fetchFile } from "@ffmpeg/util";
+
+interface Segment {
+  url: string;
+  name: string;
+}
+
+export default function AudioSplitter() {
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [audioPreviewUrl, setAudioPreviewUrl] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [splitPoints, setSplitPoints] = useState<string[]>(["30"]);
+  const [ffmpegLoaded, setFfmpegLoaded] = useState(false);
+  const [loadingFFmpeg, setLoadingFFmpeg] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [audioDuration, setAudioDuration] = useState<number | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const ffmpegRef = useRef<FFmpeg | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const loadFFmpeg = async () => {
+    if (ffmpegLoaded) return;
+    setLoadingFFmpeg(true);
+    setError(null);
+    try {
+      const ffmpeg = new FFmpeg();
+      ffmpegRef.current = ffmpeg;
+      ffmpeg.on("progress", ({ progress: prog }) => {
+        setProgress(Math.round(prog * 100));
+      });
+      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+      await ffmpeg.load({
+        coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+        wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      });
+      setFfmpegLoaded(true);
+    } catch {
+      setError("Failed to load audio processor. Please try again.");
+    } finally {
+      setLoadingFFmpeg(false);
+    }
+  };
+
+  const setFile = (file: File) => {
+    setAudioFile(file);
+    setAudioPreviewUrl(URL.createObjectURL(file));
+    setSegments([]);
+    setError(null);
+    setProgress(0);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith("audio/")) setFile(file);
+  };
+
+  const handleAudioLoaded = () => {
+    if (audioRef.current) {
+      setAudioDuration(audioRef.current.duration);
+    }
+  };
+
+  const addSplitPoint = () => setSplitPoints([...splitPoints, ""]);
+
+  const removeSplitPoint = (index: number) =>
+    setSplitPoints(splitPoints.filter((_, i) => i !== index));
+
+  const updateSplitPoint = (index: number, value: string) => {
+    const updated = [...splitPoints];
+    updated[index] = value;
+    setSplitPoints(updated);
+  };
+
+  const splitAudio = async () => {
+    if (!audioFile || !ffmpegRef.current) return;
+    setProcessing(true);
+    setError(null);
+    setProgress(0);
+    setSegments([]);
+    try {
+      const ffmpeg = ffmpegRef.current;
+      const ext = audioFile.name.split(".").pop()?.toLowerCase() || "mp3";
+      const baseName = audioFile.name.replace(/\.[^/.]+$/, "");
+      await ffmpeg.writeFile(`input.${ext}`, await fetchFile(audioFile));
+
+      const sortedPoints = splitPoints
+        .map(Number)
+        .filter((n) => !isNaN(n) && n > 0)
+        .sort((a, b) => a - b);
+
+      const duration = audioDuration ?? 0;
+      const boundaries = [0, ...sortedPoints, duration];
+      const newSegments: Segment[] = [];
+
+      for (let i = 0; i < boundaries.length - 1; i++) {
+        const start = boundaries[i];
+        const end = boundaries[i + 1];
+        const outName = `segment_${i}.${ext}`;
+        await ffmpeg.exec([
+          "-i", `input.${ext}`,
+          "-ss", String(start),
+          "-to", String(end),
+          "-c", "copy",
+          outName,
+        ]);
+        const data = await ffmpeg.readFile(outName);
+        const blob = new Blob([data], { type: audioFile.type });
+        newSegments.push({
+          url: URL.createObjectURL(blob),
+          name: `${baseName}_part${i + 1}.${ext}`,
+        });
+        setProgress(Math.round(((i + 1) / (boundaries.length - 1)) * 100));
+      }
+      setSegments(newSegments);
+    } catch {
+      setError("Failed to split audio. Please try a different file.");
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const downloadSegment = (url: string, name: string) => {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = name;
+    link.click();
+  };
+
+  const reset = () => {
+    setAudioFile(null);
+    setAudioPreviewUrl(null);
+    setSegments([]);
+    setProgress(0);
+    setError(null);
+    setSplitPoints(["30"]);
+    setAudioDuration(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-sky-900 via-blue-800 to-sky-900 py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2">Audio Splitter</h1>
+          <p className="text-gray-300">
+            Split an audio file into multiple segments at custom time points
+          </p>
+        </div>
+
+        {!ffmpegLoaded && (
+          <div className="bg-gray-800 rounded-lg p-8 text-center shadow-xl mb-6">
+            <h2 className="text-xl font-semibold text-white mb-4">Initialize Audio Processor</h2>
+            <p className="text-gray-300 mb-6">
+              Click below to load the audio engine. No files are uploaded — everything runs locally.
+            </p>
+            <button
+              onClick={loadFFmpeg}
+              disabled={loadingFFmpeg}
+              className="bg-sky-600 hover:bg-sky-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-8 rounded-lg transition-colors"
+            >
+              {loadingFFmpeg ? "Loading..." : "Load Audio Processor"}
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-6">
+            <p className="text-red-200">{error}</p>
+          </div>
+        )}
+
+        {ffmpegLoaded && !audioFile && (
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => fileInputRef.current?.click()}
+            className="border-4 border-dashed border-gray-600 rounded-lg p-12 text-center cursor-pointer hover:border-sky-500 transition-colors bg-gray-800/50"
+          >
+            <p className="text-xl text-gray-300 mb-2">Click to upload or drag and drop</p>
+            <p className="text-sm text-gray-500">MP3, WAV, OGG, AAC, FLAC, and more</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="audio/*"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </div>
+        )}
+
+        {ffmpegLoaded && audioFile && (
+          <div className="space-y-6">
+            <div className="bg-gray-800 rounded-lg p-6 shadow-xl">
+              <h2 className="text-xl font-semibold text-white mb-4">Original Audio</h2>
+              <audio
+                ref={audioRef}
+                src={audioPreviewUrl ?? undefined}
+                controls
+                onLoadedMetadata={handleAudioLoaded}
+                className="w-full mb-2"
+              />
+              {audioDuration !== null && (
+                <p className="text-gray-400 text-sm mb-6">
+                  Duration: {audioDuration.toFixed(1)}s
+                </p>
+              )}
+
+              <h2 className="text-xl font-semibold text-white mb-3">Split Points (seconds)</h2>
+              <p className="text-gray-400 text-sm mb-4">
+                Define where to cut the audio. The file will be split into {splitPoints.length + 1} segments.
+              </p>
+              <div className="space-y-3 mb-4">
+                {splitPoints.map((point, i) => (
+                  <div key={i} className="flex gap-3 items-center">
+                    <input
+                      type="number"
+                      min="0"
+                      value={point}
+                      onChange={(e) => updateSplitPoint(i, e.target.value)}
+                      placeholder="Split at (seconds)"
+                      className="flex-1 bg-gray-700 text-white px-4 py-2 rounded-lg border border-gray-600 focus:border-sky-500 focus:outline-none"
+                    />
+                    <button
+                      onClick={() => removeSplitPoint(i)}
+                      disabled={splitPoints.length === 1}
+                      className="bg-red-600 hover:bg-red-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white px-3 py-2 rounded-lg transition-colors"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <button
+                onClick={addSplitPoint}
+                className="text-sm text-sky-400 hover:text-sky-300 transition-colors mb-6"
+              >
+                + Add split point
+              </button>
+
+              {processing && (
+                <div className="mb-6">
+                  <div className="flex justify-between text-sm text-gray-300 mb-2">
+                    <span>Processing segments...</span>
+                    <span>{progress}%</span>
+                  </div>
+                  <div className="w-full bg-gray-700 rounded-full h-3">
+                    <div
+                      className="bg-sky-600 h-3 rounded-full transition-all duration-300"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="flex gap-4">
+                <button
+                  onClick={splitAudio}
+                  disabled={processing}
+                  className="flex-1 bg-sky-600 hover:bg-sky-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  {processing ? "Splitting..." : "Split Audio"}
+                </button>
+                <button
+                  onClick={reset}
+                  className="bg-red-600 hover:bg-red-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+
+            {segments.length > 0 && (
+              <div className="bg-gray-800 rounded-lg p-6 shadow-xl space-y-4">
+                <h3 className="text-lg font-semibold text-white">
+                  Segments ({segments.length})
+                </h3>
+                {segments.map((seg, i) => (
+                  <div key={i} className="border border-gray-700 rounded-lg p-4">
+                    <div className="flex justify-between items-center mb-3">
+                      <span className="text-white font-medium">Part {i + 1}</span>
+                      <button
+                        onClick={() => downloadSegment(seg.url, seg.name)}
+                        className="bg-green-600 hover:bg-green-700 text-white text-sm px-4 py-1 rounded-lg transition-colors"
+                      >
+                        Download
+                      </button>
+                    </div>
+                    <audio src={seg.url} controls className="w-full" />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="bg-sky-900/30 border border-sky-700 rounded-lg p-4">
+              <h3 className="text-sm font-semibold text-sky-300 mb-2">About this tool:</h3>
+              <ul className="text-sm text-sky-200 space-y-1">
+                <li>• All processing happens in your browser — no files are uploaded</li>
+                <li>• Add as many split points as needed</li>
+                <li>• Each segment can be previewed and downloaded independently</li>
+                <li>• Uses stream copy for fast, lossless splitting</li>
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/tools/audioTrimmer/page.tsx
+++ b/app/tools/audioTrimmer/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL, fetchFile } from "@ffmpeg/util";
+
+export default function AudioTrimmer() {
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [audioPreviewUrl, setAudioPreviewUrl] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [trimmedUrl, setTrimmedUrl] = useState<string | null>(null);
+  const [ffmpegLoaded, setFfmpegLoaded] = useState(false);
+  const [loadingFFmpeg, setLoadingFFmpeg] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [startTime, setStartTime] = useState("0");
+  const [endTime, setEndTime] = useState("");
+  const [audioDuration, setAudioDuration] = useState<number | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const ffmpegRef = useRef<FFmpeg | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const loadFFmpeg = async () => {
+    if (ffmpegLoaded) return;
+    setLoadingFFmpeg(true);
+    setError(null);
+    try {
+      const ffmpeg = new FFmpeg();
+      ffmpegRef.current = ffmpeg;
+      ffmpeg.on("progress", ({ progress: prog }) => {
+        setProgress(Math.round(prog * 100));
+      });
+      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+      await ffmpeg.load({
+        coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+        wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      });
+      setFfmpegLoaded(true);
+    } catch {
+      setError("Failed to load audio processor. Please try again.");
+    } finally {
+      setLoadingFFmpeg(false);
+    }
+  };
+
+  const setFile = (file: File) => {
+    setAudioFile(file);
+    setAudioPreviewUrl(URL.createObjectURL(file));
+    setTrimmedUrl(null);
+    setError(null);
+    setProgress(0);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith("audio/")) setFile(file);
+  };
+
+  const handleAudioLoaded = () => {
+    if (audioRef.current) {
+      const duration = audioRef.current.duration;
+      setAudioDuration(duration);
+      setEndTime(Math.floor(duration).toString());
+    }
+  };
+
+  const trimAudio = async () => {
+    if (!audioFile || !ffmpegRef.current) return;
+    setProcessing(true);
+    setError(null);
+    setProgress(0);
+    try {
+      const ffmpeg = ffmpegRef.current;
+      const ext = audioFile.name.split(".").pop()?.toLowerCase() || "mp3";
+      await ffmpeg.writeFile(`input.${ext}`, await fetchFile(audioFile));
+      await ffmpeg.exec([
+        "-i", `input.${ext}`,
+        "-ss", startTime,
+        ...(endTime ? ["-to", endTime] : []),
+        "-c", "copy",
+        `output.${ext}`,
+      ]);
+      const data = await ffmpeg.readFile(`output.${ext}`);
+      const blob = new Blob([data], { type: audioFile.type });
+      setTrimmedUrl(URL.createObjectURL(blob));
+      setProgress(100);
+    } catch {
+      setError("Failed to trim audio. Please try a different file.");
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const download = () => {
+    if (!trimmedUrl || !audioFile) return;
+    const link = document.createElement("a");
+    link.href = trimmedUrl;
+    const base = audioFile.name.replace(/\.[^/.]+$/, "");
+    const ext = audioFile.name.split(".").pop() || "mp3";
+    link.download = `${base}_trimmed.${ext}`;
+    link.click();
+  };
+
+  const reset = () => {
+    setAudioFile(null);
+    setAudioPreviewUrl(null);
+    setTrimmedUrl(null);
+    setProgress(0);
+    setError(null);
+    setStartTime("0");
+    setEndTime("");
+    setAudioDuration(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-900 via-orange-800 to-amber-900 py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2">Audio Trimmer</h1>
+          <p className="text-gray-300">Cut audio to any start and end point — runs entirely in your browser</p>
+        </div>
+
+        {!ffmpegLoaded && (
+          <div className="bg-gray-800 rounded-lg p-8 text-center shadow-xl mb-6">
+            <h2 className="text-xl font-semibold text-white mb-4">Initialize Audio Processor</h2>
+            <p className="text-gray-300 mb-6">
+              Click below to load the audio engine. No files are uploaded — everything runs locally.
+            </p>
+            <button
+              onClick={loadFFmpeg}
+              disabled={loadingFFmpeg}
+              className="bg-amber-600 hover:bg-amber-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-8 rounded-lg transition-colors"
+            >
+              {loadingFFmpeg ? "Loading..." : "Load Audio Processor"}
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-6">
+            <p className="text-red-200">{error}</p>
+          </div>
+        )}
+
+        {ffmpegLoaded && !audioFile && (
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => fileInputRef.current?.click()}
+            className="border-4 border-dashed border-gray-600 rounded-lg p-12 text-center cursor-pointer hover:border-amber-500 transition-colors bg-gray-800/50"
+          >
+            <p className="text-xl text-gray-300 mb-2">Click to upload or drag and drop</p>
+            <p className="text-sm text-gray-500">MP3, WAV, OGG, AAC, FLAC, and more</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="audio/*"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </div>
+        )}
+
+        {ffmpegLoaded && audioFile && (
+          <div className="space-y-6">
+            <div className="bg-gray-800 rounded-lg p-6 shadow-xl">
+              <h2 className="text-xl font-semibold text-white mb-4">Original Audio</h2>
+              <audio
+                ref={audioRef}
+                src={audioPreviewUrl ?? undefined}
+                controls
+                onLoadedMetadata={handleAudioLoaded}
+                className="w-full mb-2"
+              />
+              {audioDuration !== null && (
+                <p className="text-gray-400 text-sm mb-6">
+                  Duration: {audioDuration.toFixed(1)}s
+                </p>
+              )}
+
+              <h2 className="text-xl font-semibold text-white mb-4">Trim Settings</h2>
+              <div className="grid grid-cols-2 gap-4 mb-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Start (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={startTime}
+                    onChange={(e) => setStartTime(e.target.value)}
+                    className="w-full bg-gray-700 text-white px-4 py-2 rounded-lg border border-gray-600 focus:border-amber-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-2">
+                    End (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    min="0"
+                    value={endTime}
+                    onChange={(e) => setEndTime(e.target.value)}
+                    placeholder="End of file"
+                    className="w-full bg-gray-700 text-white px-4 py-2 rounded-lg border border-gray-600 focus:border-amber-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+
+              {processing && (
+                <div className="mb-6">
+                  <div className="flex justify-between text-sm text-gray-300 mb-2">
+                    <span>Processing...</span>
+                    <span>{progress}%</span>
+                  </div>
+                  <div className="w-full bg-gray-700 rounded-full h-3">
+                    <div
+                      className="bg-amber-600 h-3 rounded-full transition-all duration-300"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="flex gap-4">
+                {!trimmedUrl ? (
+                  <button
+                    onClick={trimAudio}
+                    disabled={processing}
+                    className="flex-1 bg-amber-600 hover:bg-amber-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                  >
+                    {processing ? "Trimming..." : "Trim Audio"}
+                  </button>
+                ) : (
+                  <button
+                    onClick={download}
+                    className="flex-1 bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                  >
+                    Download Trimmed Audio
+                  </button>
+                )}
+                <button
+                  onClick={reset}
+                  className="bg-red-600 hover:bg-red-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+
+            {trimmedUrl && (
+              <div className="bg-gray-800 rounded-lg p-6 shadow-xl">
+                <h3 className="text-lg font-semibold text-white mb-4">Trimmed Audio</h3>
+                <audio src={trimmedUrl} controls className="w-full" />
+              </div>
+            )}
+
+            <div className="bg-amber-900/30 border border-amber-700 rounded-lg p-4">
+              <h3 className="text-sm font-semibold text-amber-300 mb-2">About this tool:</h3>
+              <ul className="text-sm text-amber-200 space-y-1">
+                <li>• All processing happens in your browser — no files are uploaded</li>
+                <li>• Supports MP3, WAV, OGG, AAC, FLAC, and more</li>
+                <li>• Uses stream copy for fast, lossless trimming</li>
+                <li>• Leave the end time blank to trim from start to end of file</li>
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -91,6 +91,24 @@ const tools = [
     href: "/tools/videoEditor",
     color: "from-teal-500 to-cyan-600",
   },
+  {
+    name: "Audio Trimmer",
+    description: "Cut audio files to any start and end time, right in your browser.",
+    href: "/tools/audioTrimmer",
+    color: "from-amber-500 to-orange-600",
+  },
+  {
+    name: "Audio Splitter",
+    description: "Split audio into multiple segments at custom time points.",
+    href: "/tools/audioSplitter",
+    color: "from-sky-500 to-blue-600",
+  },
+  {
+    name: "Audio Pitch Shifter",
+    description: "Raise or lower the pitch of any audio file by semitones.",
+    href: "/tools/audioPitchShifter",
+    color: "from-violet-500 to-purple-600",
+  },
 ];
 
 export default function ToolsIndex() {

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+# Esteban Dalel R
+
+> Personal website and collection of browser-based tools built by Esteban Dalel R. All tools run entirely client-side — no files are uploaded to a server.
+
+## Pages
+
+- [Home](https://www.estebandalelr.co/): Portfolio homepage with profile and social links.
+- [Tools](https://www.estebandalelr.co/tools): Directory of all available browser tools.
+- [Deep Connection](https://www.estebandalelr.co/deep): Card game with tiered questions for couples.
+- [Money Splitter](https://www.estebandalelr.co/money): Group expense tracker and settlement calculator.
+
+## Tools
+
+- [Character Count](https://www.estebandalelr.co/tools/characterCount): Detailed character, word, and sentence statistics for any text.
+- [Text Diff](https://www.estebandalelr.co/tools/textDiff): Side-by-side text comparison with highlighted differences.
+- [Image Trace](https://www.estebandalelr.co/tools/imageTrace): Convert images to traced outlines for laser etching using Sobel edge detection.
+- [Paint by Numbers](https://www.estebandalelr.co/tools/paintByNumbers): Convert an image into a paint-by-numbers artwork.
+- [Embroidery Tracer](https://www.estebandalelr.co/tools/embroideryTracer): Generate SVG paths from images for embroidery patterns.
+- [QR Code Generator](https://www.estebandalelr.co/tools/qr): Create custom QR codes from any text or URL.
+- [Video Converter](https://www.estebandalelr.co/tools/videoConverter): Convert videos between AVI, MP4, MOV, WebM, and MKV using FFmpeg WASM.
+- [Stop Motion Editor](https://www.estebandalelr.co/tools/videoEditor): Upload images to create stop motion animations.
+- [Audio Trimmer](https://www.estebandalelr.co/tools/audioTrimmer): Cut audio files to any start and end time using FFmpeg WASM.
+- [Audio Splitter](https://www.estebandalelr.co/tools/audioSplitter): Split audio into multiple segments at custom time points using FFmpeg WASM.
+- [Audio Pitch Shifter](https://www.estebandalelr.co/tools/audioPitchShifter): Raise or lower the pitch of audio files by semitones using FFmpeg WASM.
+- [Piano](https://www.estebandalelr.co/tools/piano): Interactive keyboard with chords and melodies.
+- [Morse Code](https://www.estebandalelr.co/tools/morse): Learn and practice Morse code with audio playback via Web Audio API.
+- [ASL Learning](https://www.estebandalelr.co/tools/asl): American Sign Language alphabet and numbers flashcards.
+- [Braille](https://www.estebandalelr.co/tools/braille): Interactive Braille alphabet learning tool.
+- [Cursive](https://www.estebandalelr.co/tools/cursive): Practice cursive handwriting with letters and common words.
+- [Swedish Learning](https://www.estebandalelr.co/tools/swedish): Flashcards and quizzes for Swedish vocabulary.
+- [Portuguese Learning](https://www.estebandalelr.co/tools/portuguese): Portuguese vocabulary, verbs, and common phrases.


### PR DESCRIPTION
## Summary
Added three new browser-based audio processing tools that run entirely client-side using FFmpeg WASM. These tools allow users to trim, split, and pitch-shift audio files without uploading to a server.

## Key Changes
- **Audio Trimmer** (`app/tools/audioTrimmer/page.tsx`): Allows users to cut audio files by specifying start and end times. Features include audio preview, duration display, and lossless stream copying for fast processing.

- **Audio Splitter** (`app/tools/audioSplitter/page.tsx`): Enables splitting audio into multiple segments at custom time points. Users can add/remove split points dynamically, preview segments, and download each part independently.

- **Audio Pitch Shifter** (`app/tools/audioPitchShifter/page.tsx`): Shifts audio pitch by semitones (−12 to +12) with tempo compensation to maintain original playback speed. Includes an interactive slider for real-time pitch adjustment.

- **Tools Directory Update** (`app/tools/page.tsx`): Added three new tool cards to the tools index page with appropriate color schemes and descriptions.

- **Documentation** (`llms.txt`): Updated project documentation to include the new audio tools.

## Implementation Details
- All three tools follow the same pattern: lazy FFmpeg WASM loading, file upload via drag-and-drop or click, real-time progress tracking, and client-side processing
- Uses FFmpeg's `-c copy` flag for lossless trimming and splitting operations
- Pitch shifting uses `asetrate` and `atempo` filters to adjust pitch while compensating for speed changes
- Each tool has distinct color theming (amber/orange for trimmer, sky/blue for splitter, violet/purple for pitch shifter)
- Includes error handling, progress indicators, and informational sections explaining privacy and capabilities

https://claude.ai/code/session_01AXSU2BuzijVLqVYn2Ha9sy